### PR TITLE
Version 0.4.4: More bugfixes in Foil and WingMesh

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AeroFuse"
 uuid = "477c59f4-51f5-487f-bf1e-8db39645b227"
 authors = ["GodotMisogi <arjitseth@gmail.com>"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you use AeroFuse in your research, please cite the following until any releva
   author  = {Arjit Seth, Rhea P. Liem},
   title   = {AeroFuse},
   url     = {https://github.com/GodotMisogi/AeroFuse},
-  version = {0.4.3},
+  version = {0.4.4},
   date    = {2023-03-14},
 }
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,7 +53,7 @@ If you use AeroFuse in your research, please cite the following until any releva
   author  = {Arjit Seth, Rhea P. Liem},
   title   = {AeroFuse},
   url     = {https://github.com/GodotMisogi/AeroFuse},
-  version = {0.4.3},
+  version = {0.4.4},
   date    = {2023-03-14},
 }
 ```

--- a/examples/geometry/foil.jl
+++ b/examples/geometry/foil.jl
@@ -2,10 +2,14 @@ using AeroFuse
 using Plots
 
 ## NACA
-naca_foil = naca4(2,4,1,2) # NACA 4-digit
+naca_foil = naca4(4,6,3,6) # NACA 4-digit
 
 ## Plot
-plot(naca_foil)
+plot(naca_foil, 
+    aspect_ratio = 1, 
+    camber = true, 
+    thickness = true
+)
 
 ## Fitting to Kulfan Class Shape Transformation parametrisation
 num_dv = 8

--- a/src/Geometry/AircraftGeometry/Foils/foil.jl
+++ b/src/Geometry/AircraftGeometry/Foils/foil.jl
@@ -129,10 +129,19 @@ end
 function camber_line(foil :: Foil, n = 60)
     upper, lower = split_surface(foil)
     xs  = LinRange(minimum(foil.x), maximum(foil.x), n + 1)
-    y_u = @views linear_interpolation(upper[:,1], upper[:,2]).(xs)
-    y_l = @views linear_interpolation(lower[:,1], lower[:,2]).(xs)
+    y_u = @views map(linear_interpolation(upper[:,1], upper[:,2]), xs)
+    y_l = @views map(linear_interpolation(lower[:,1], lower[:,2]), xs)
 
     [ xs (y_u + y_l) / 2 ]
+end
+
+function thickness_line(foil :: Foil, n = 60)
+    upper, lower = split_surface(foil)
+    xs  = LinRange(minimum(foil.x), maximum(foil.x), n + 1)
+    y_u = @views map(linear_interpolation(upper[:,1], upper[:,2]), xs)
+    y_l = @views map(linear_interpolation(lower[:,1], lower[:,2]), xs)
+
+    [ xs (y_u - y_l) ]
 end
 
 

--- a/src/Geometry/AircraftGeometry/Wings/halfwing.jl
+++ b/src/Geometry/AircraftGeometry/Wings/halfwing.jl
@@ -69,12 +69,17 @@ function Wing(;
 end
 
 function check_wing(foils, chords, twists, spans, dihedrals, sweeps)
-    # Check if number of sections match up with number of edges (NEEDS WORK)
-    @assert (length ∘ zip)(foils, chords, twists) == (length ∘ zip)(spans, dihedrals, sweeps) + 1 "N+1 foils, chords and twists are required for N section(s)."
+    # Check if number of sections match up with number of edges
+    nf, nc, nt = length(foils), length(chords), length(twists)
+    nb, nd, ns = length(spans), length(dihedrals), length(spans)
+    @assert nf == nc == nt "Number of foils, chords and twists specified must be the same!"
+    @assert nb == nd == ns "Number of spans, dihedrals, and sweeps specified must be the same!"
+    @assert nf == ns + 1 "$(nf+1) foils, chords and twists are required for $ns spanwise section(s)."
+
     # Check if lengths are positive
-    @assert any(x -> x >= 0., chords) || any(x -> x >= 0., spans) "Chord and span lengths must be positive."
+    @assert any(x -> x >= zero(eltype(x)), chords) | any(x -> x >= zero(eltype(x)), spans) "Chord and span lengths must be positive."
     # Check if dihedrals and sweeps are within bounds
-    @assert any(x -> x >= -90. || x <= 90., dihedrals) || any(x -> x >= -90. || x <= 90., sweeps) "Dihedrals and sweep angles must not exceed ±90ᵒ."
+    @assert all(x -> x > -convert(typeof(x), 90) && x < convert(typeof(x), 90), dihedrals) && all(x -> x > -convert(typeof(x), 90) && x < convert(typeof(x), 90), sweeps) "Dihedrals and sweep angles must not exceed ±90ᵒ."
 end
 
 

--- a/src/Geometry/AircraftGeometry/Wings/mesh_wing.jl
+++ b/src/Geometry/AircraftGeometry/Wings/mesh_wing.jl
@@ -55,7 +55,7 @@ function camber_coordinates(wing :: Wing, span_num :: Vector{<: Integer}, chord_
     scaled_foils =  map((c, foil) -> c * camber_coordinates(camber_thickness(foil, chord_num)), wing.chords, wing.foils) 
 
     # # Discretize spanwise sections
-    coords = chop_spanwise_sections(scaled_foils, deg2rad.(wing.twists), leading_xyz, span_num, span_spacing, wing.symmetry, wing.flip)
+    coords = chop_spanwise_sections(scaled_foils, -deg2rad.(wing.twists), leading_xyz, span_num, span_spacing, wing.symmetry, wing.flip)
 
     # # Transform
     return map(wing.affine, coords)
@@ -69,7 +69,7 @@ function surface_coordinates(wing :: Wing, span_num :: Vector{<: Integer}, chord
     scaled_foils = @. wing.chords * (extend_yz ∘ coordinates ∘ cosine_interpolation)(reflect.(wing.foils), chord_num)
 
     # Discretize spanwise sections
-    coords = chop_spanwise_sections(scaled_foils, deg2rad.(wing.twists), leading_xyz, span_num, span_spacing, wing.symmetry, wing.flip)
+    coords = chop_spanwise_sections(scaled_foils, -deg2rad.(wing.twists), leading_xyz, span_num, span_spacing, wing.symmetry, wing.flip)
 
     # Transform
     return map(wing.affine, coords)

--- a/src/Tools/plot_tools.jl
+++ b/src/Tools/plot_tools.jl
@@ -78,21 +78,20 @@ end
     # aspect_ratio --> 1
     label --> foil.name
 
-    if camber || thickness
-        xcamthick = camber_thickness(foil)
-        if camber
-            @series begin
-                ls := :dash
-                label := foil.name * " Camber"
-                xcamthick[:,1], xcamthick[:,2]
-            end
+    if camber
+        xcam = camber_line(foil)
+        @series begin
+            ls := :dash
+            label := foil.name * " Camber"
+            xcam[:,1], xcam[:,2]
         end
-        if thickness
-            @series begin
-                ls := :dot
-                label := foil.name * " Thickness"
-                xcamthick[:,1], xcamthick[:,3]
-            end
+    end
+    if thickness
+        xthicc = thickness_line(foil)
+        @series begin
+            ls := :dot
+            label := foil.name * " Thickness"
+            xthicc[:,1], xthicc[:,2]
         end
     end
 


### PR DESCRIPTION
- Plots switched to linear interpolation for camber and thickness of `Foil` to avoid potential errors with cosine interpolation: 597f65d0bea10b551cfef1773899644b28d4bdb9
- The logical physicality checks while constructing `Wing` have been corrected: 597f65d0bea10b551cfef1773899644b28d4bdb9
- An error introduced in a recent merge (twist angle signs flipped in camber and surface mesh generation) has been fixed: 597f65d0bea10b551cfef1773899644b28d4bdb9