### PR TITLE
Version 0.4.9: Fixed Freestream constructor and updated docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AeroFuse"
 uuid = "477c59f4-51f5-487f-bf1e-8db39645b227"
 authors = ["GodotMisogi <arjitseth@gmail.com>"]
-version = "0.4.8"
+version = "0.4.9"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you use AeroFuse in your research, please cite the following until any releva
   author  = {Arjit Seth, Rhea P. Liem},
   title   = {AeroFuse},
   url     = {https://github.com/GodotMisogi/AeroFuse},
-  version = {0.4.8},
+  version = {0.4.9},
   date    = {2023-04-10},
 }
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -61,7 +61,7 @@ If you use AeroFuse in your research, please cite the following until any releva
   author  = {Arjit Seth, Rhea P. Liem},
   title   = {AeroFuse},
   url     = {https://github.com/GodotMisogi/AeroFuse},
-  version = {0.4.8},
+  version = {0.4.9},
   date    = {2023-03-27},
 }
 ```

--- a/src/Tools/Laplace.jl
+++ b/src/Tools/Laplace.jl
@@ -284,6 +284,6 @@ freestream_to_cartesian(r, θ, φ) = r * SVector(cos(θ) * cos(φ), -sin(φ), si
 
 Convert Cartesian coordinates to freestream (spherical polar) flow coordinates.
 """
-cartesian_to_freestream(U) = SVector(norm(U), -atand(U[3], U[1]), -atand(U[2], √(U[1]^2 + U[3]^2)))
+cartesian_to_freestream(U) = SVector(norm(U), atand(-U[3], -U[1]), atand(U[2], √(U[1]^2 + U[3]^2)))
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,11 +198,11 @@ end
     V_test = [ cosd(θ) * cosd(φ), -sind(φ), sind(θ) * cosd(φ) ]
     V_run = velocity(fs)
 
-    φ_test, θ_test = cartesian_to_freestream(V_run)
+    φ_test, θ_test = AeroFuse.cartesian_to_freestream(-V_run)
 
     @test V_run ≈ V_test atol = 1e-6
     @test φ_test ≈ φ atol = 1e-6
-    @test θ_test ≈ -θ atol = 1e-6
+    @test θ_test ≈ θ atol = 1e-6
 end
 
 @testset "Aerodynamics - Reference Values" begin


### PR DESCRIPTION
Minor changes:

- The `Freestream` constructor had the wrong computations for the 3D velocity as input, now fixed: 4c0a567cecead42a1222bba52c5579b640b458ac
- The docstrings for `Foil` methods have been updated: 91227810993201ee6fa470b1e9b80fb76b767cf2